### PR TITLE
fixed namespace in typo in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "bonnier/contenthub-editor",
+  "name": "benjaminmedia/contenthub-editor",
   "description": "Integrates Bonnier ContentHub into WordPress",
   "type": "wordpress-plugin",
   "keywords": ["wordpress", "plugin"],


### PR DESCRIPTION
For some reason, I cannot get it to work on Composer, as it says there's no stable version.

However, there was an inconsistency between package name and according to this
[Correctly setup package.json file](https://github.com/BenjaminMedia/wp-wa-oauth/blob/master/composer.json), it appears that the name might be wrong.