### PR TITLE
Added code to make files private in s3 and issue signed urls for admin viewing

### DIFF
--- a/src/Commands/Composites.php
+++ b/src/Commands/Composites.php
@@ -26,15 +26,26 @@ class Composites extends BaseCmd
     }
 
     /**
-     * Imports composites from Scahpold
+     * Imports composites from Scaphold
+     *
+     * ## OPTIONS
+     *
+     *
+     * [--id=<id>]
+     * : The id of a single composite to import.
      *
      * ## EXAMPLES
-     *
      * wp contenthub editor composites import
      *
+     * @param $args
+     * @param $assocArgs
      */
-    public function import()
+    public function import($args, $assocArgs)
     {
+        if($id = $assocArgs['id'] ?? null) {
+            $this->import_composite(CompositeRepository::find_by_id($id));
+            return;
+        }
         $this->map_sites(function ($site) {
             $this->map_composites_by_brand_id($site->brand->content_hub_id, function ($composite) {
                 $this->import_composite($composite);
@@ -172,6 +183,13 @@ class Composites extends BaseCmd
                             'file' => WpAttachment::upload_attachment($postId, $image->node),
                         ];
                     }),
+                    'locked_content' => $compositeContent->locked,
+                    'acf_fc_layout' => $compositeContent->type
+                ];
+            }
+            if ($compositeContent->type === 'inserted_code') {
+                return [
+                    'code' => $compositeContent->content->code,
                     'locked_content' => $compositeContent->locked,
                     'acf_fc_layout' => $compositeContent->type
                 ];

--- a/src/Commands/Taxonomy/Categories.php
+++ b/src/Commands/Taxonomy/Categories.php
@@ -17,7 +17,7 @@ class Categories extends BaseTaxonomyImporter
 
     public static function register() {
         WP_CLI::add_command( CmdManager::CORE_CMD_NAMESPACE  . ' ' . static::CMD_NAMESPACE , __CLASS__ );
-        define(PLL_ADMIN, true); // Tell Polylang to be in admin mode so that various term filters are loaded
+        define('PLL_ADMIN', true); // Tell Polylang to be in admin mode so that various term filters are loaded
     }
 
     /**

--- a/src/Commands/Taxonomy/Tags.php
+++ b/src/Commands/Taxonomy/Tags.php
@@ -17,7 +17,7 @@ class Tags extends BaseTaxonomyImporter
 
     public static function register() {
         WP_CLI::add_command( CmdManager::CORE_CMD_NAMESPACE  . ' ' . static::CMD_NAMESPACE , __CLASS__ );
-        define(PLL_ADMIN, true); // Tell Polylang to be in admin mode so that various term filters are loaded
+        define('PLL_ADMIN', true); // Tell Polylang to be in admin mode so that various term filters are loaded
     }
 
     /**

--- a/src/Commands/Taxonomy/Vocabularies.php
+++ b/src/Commands/Taxonomy/Vocabularies.php
@@ -31,8 +31,8 @@ class Vocabularies extends BaseCmd
      */
     public function import() {
         $vocabularies = collect();
-        $this->mapSites(function($site) use($vocabularies) {
-            $this->mapVocabularies($site, function ($vocabulary) use($vocabularies) {
+        $this->map_sites(function($site) use($vocabularies) {
+            $this->map_vocabularies($site, function ($vocabulary) use($vocabularies) {
                 $vocabularies[$vocabulary->content_hub_id] = $vocabulary;
             });
         });
@@ -40,7 +40,7 @@ class Vocabularies extends BaseCmd
         WP_CLI::success( 'Done importing Vocabularies' );
     }
 
-    protected function mapVocabularies($site, $callable)
+    protected function map_vocabularies($site, $callable)
     {
         $vocabularies = VocabularyRepository::find_by_app_id($site->app->id);
 

--- a/src/Models/ACF/Composite/TeaserFieldGroup.php
+++ b/src/Models/ACF/Composite/TeaserFieldGroup.php
@@ -24,7 +24,7 @@ class TeaserFieldGroup
                         'key' => 'field_58e38d86194e2',
                         'label' => 'Title',
                         'name' => 'teaser_title',
-                        'type' => 'markdown-editor',
+                        'type' => 'text',
                         'instructions' => '',
                         'required' => 0,
                         'conditional_logic' => 0,
@@ -33,17 +33,6 @@ class TeaserFieldGroup
                             'class' => '',
                             'id' => '',
                         ],
-                        'simple_mde_config' => json_encode([
-                            'max-height' => '100px',
-                            'height' => '100px',
-                            'toolbar' => [
-                                'bold',
-                                'italic',
-                                '|',
-                                'preview',
-                                'guide'
-                            ]
-                        ]),
                         'default_value' => '',
                         'placeholder' => '',
                         'maxlength' => '',

--- a/src/Models/WpComposite.php
+++ b/src/Models/WpComposite.php
@@ -52,6 +52,7 @@ class WpComposite
                     'has_archive' => false,
                     'supports' => [
                         'title',
+                        'author'
                     ],
                 ]
             );


### PR DESCRIPTION
- Added id parameter to composites import cmd, to test import of a
single composite with given id
- Added missing quotes to constant definition
- Corrected typo in vocabularies import cmd
- Removed markdown editor from teaser_title field
- Enabled author support on composite post type