### PR TITLE
Update WpComposite.php

### DIFF
--- a/src/Models/WpComposite.php
+++ b/src/Models/WpComposite.php
@@ -54,6 +54,9 @@ class WpComposite
                         'title',
                         'author'
                     ],
+                    'taxonomies' => [
+                        'category'
+                    ],
                 ]
             );
             static::register_acf_fields();


### PR DESCRIPTION
To fix breadcrumbs via Yoast, we'll need to register category as a taxonomy for our custom post type.