### PR TITLE
creating new content results in an error 500, because of WP trying to…

### DIFF
--- a/src/Models/WpComposite.php
+++ b/src/Models/WpComposite.php
@@ -193,6 +193,9 @@ class WpComposite
     }
 
     public static function on_save($postId, WP_Post $post) {
+        if (wp_is_post_revision($post->ID) || wp_is_post_autosave($post->ID)) {
+            return;
+        }
         if($post->post_type === static::POST_TYPE) {
 
             $contentHubId = get_post_meta($postId, static::POST_META_CONTENTHUB_ID, true);


### PR DESCRIPTION
… get an ID from scaphold