### PR TITLE
WILL-1027/BUGFIX: BOB import wrong locale

### DIFF
--- a/contenthub-editor.php
+++ b/contenthub-editor.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: ContentHub Editor
- * Version: 4.10.0
+ * Version: 4.10.1
  * Plugin URI: https://github.com/BenjaminMedia/contenthub-editor
  * Description: This plugin integrates Bonnier Contenthub and adds a custom post type Composite
  * Author: Bonnier - Alf Henderson


### PR DESCRIPTION
Fixes an issue where importing content without a language caused the article to be created in danish, along with the tags and categories associated.