### PR TITLE
BUGFIX - Removing polylang as composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,21 +38,6 @@
           "junaidbhura/composer-wp-pro-plugins": "*"
         }
       }
-    },
-    {
-      "type": "package",
-      "package": {
-        "name": "junaidbhura/polylang-pro",
-        "version": "2.3.8",
-        "type": "wordpress-plugin",
-        "dist": {
-          "type": "zip",
-          "url": "https://www.polylang.pro"
-        },
-        "require": {
-          "junaidbhura/composer-wp-pro-plugins": "*"
-        }
-      }
     }
   ],
   "support": {

--- a/contenthub-editor.php
+++ b/contenthub-editor.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: ContentHub Editor
- * Version: 5.4.0
+ * Version: 5.5.0
  * Plugin URI: https://github.com/BenjaminMedia/contenthub-editor
  * Description: This plugin integrates Bonnier Contenthub and adds a custom post type Composite
  * Author: Bonnier - Alf Henderson


### PR DESCRIPTION
The Polylang composer dependency will always install the latest version of the plugin instead of the specified version number. Therefore we need to add the plugin manually, to ensure we are on the correct version.