### PR TITLE
His 36/import missing description

### DIFF
--- a/contenthub-editor.php
+++ b/contenthub-editor.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: ContentHub Editor
- * Version: 5.7.2
+ * Version: 5.8.0
  * Plugin URI: https://github.com/BenjaminMedia/contenthub-editor
  * Description: This plugin integrates Bonnier Contenthub and adds a custom post type Composite
  * Author: Bonnier - Alf Henderson

--- a/src/Commands/WaContent.php
+++ b/src/Commands/WaContent.php
@@ -47,7 +47,7 @@ class WaContent extends BaseCmd
     public function prune($args, $assocArgs)
     {
         WpComposite::map_all(function (WP_Post $post) {
-            if ($waId = WpComposite::white_albun_id_form_post_id($post->ID)) {
+            if ($waId = WpComposite::white_album_id_form_post_id($post->ID)) {
                 $repository = new ContentRepository(LanguageProvider::getPostLanguage($post->ID));
                 $content = $repository->findById($waId, ContentRepository::ARTICLE_RESOURCE) ?:
                     $repository->findById($waId, ContentRepository::GALLERY_RESOURCE);

--- a/src/Commands/WaContent.php
+++ b/src/Commands/WaContent.php
@@ -46,12 +46,12 @@ class WaContent extends BaseCmd
      */
     public function prune($args, $assocArgs)
     {
-        WpComposite::map_all(function (WP_Post $post){
-            if($waId = WpComposite::white_albun_id_form_post_id($post->ID)) {
+        WpComposite::map_all(function (WP_Post $post) {
+            if ($waId = WpComposite::white_albun_id_form_post_id($post->ID)) {
                 $repository = new ContentRepository(LanguageProvider::getPostLanguage($post->ID));
                 $content = $repository->findById($waId, ContentRepository::ARTICLE_RESOURCE) ?:
                     $repository->findById($waId, ContentRepository::GALLERY_RESOURCE);
-                if(!$content) {
+                if (!$content) {
                     wp_trash_post($post->ID);
                     WP_CLI::success(sprintf(
                         'Trashed orphaned content: %s id: %s',

--- a/src/Commands/WaContent.php
+++ b/src/Commands/WaContent.php
@@ -34,7 +34,37 @@ class WaContent extends BaseCmd
     }
 
     /**
-     * Imports composites from Scaphold
+     * Prunes imported composites from WhiteAlbum by removing those that are deleted on WhiteAlbum
+     *
+     * ## EXAMPLES
+     * wp contenthub editor wa content prune
+     *
+     * @param $args
+     * @param $assocArgs
+     *
+     * @throws \Exception
+     */
+    public function prune($args, $assocArgs)
+    {
+        WpComposite::map_all(function (WP_Post $post){
+            if($waId = WpComposite::white_albun_id_form_post_id($post->ID)) {
+                $repository = new ContentRepository(LanguageProvider::getPostLanguage($post->ID));
+                $content = $repository->findById($waId, ContentRepository::ARTICLE_RESOURCE) ?:
+                    $repository->findById($waId, ContentRepository::GALLERY_RESOURCE);
+                if(!$content) {
+                    wp_trash_post($post->ID);
+                    WP_CLI::success(sprintf(
+                        'Trashed orphaned content: %s id: %s',
+                        $post->post_title,
+                        $post->ID
+                    ));
+                }
+            }
+        });
+    }
+
+    /**
+     * Imports composites from WhiteAlbum
      *
      * ## OPTIONS
      *

--- a/src/Models/ACF/Attachment/AttachmentFieldGroup.php
+++ b/src/Models/ACF/Attachment/AttachmentFieldGroup.php
@@ -4,6 +4,9 @@ namespace Bonnier\WP\ContentHub\Editor\Models\ACF\Attachment;
 
 class AttachmentFieldGroup
 {
+   const CAPTION_FIELD_KEY =  'field_5c51b211deb49';
+
+
     public static function register()
     {
         if (function_exists('acf_add_local_field_group')) {
@@ -12,7 +15,7 @@ class AttachmentFieldGroup
                 'title' => 'Attachments',
                 'fields' => [
                     [
-                        'key' => 'field_5c51b211deb49',
+                        'key' => static::CAPTION_FIELD_KEY,
                         'label' => 'Caption',
                         'name' => 'caption',
                         'type' => 'markdown-editor',

--- a/src/Models/ACF/Attachment/AttachmentFieldGroup.php
+++ b/src/Models/ACF/Attachment/AttachmentFieldGroup.php
@@ -4,7 +4,7 @@ namespace Bonnier\WP\ContentHub\Editor\Models\ACF\Attachment;
 
 class AttachmentFieldGroup
 {
-   const CAPTION_FIELD_KEY =  'field_5c51b211deb49';
+    const CAPTION_FIELD_KEY =  'field_5c51b211deb49';
 
 
     public static function register()

--- a/src/Models/WpAttachment.php
+++ b/src/Models/WpAttachment.php
@@ -196,6 +196,7 @@ class WpAttachment
             ]
         ];
         $attachmentId = wp_insert_attachment($attachment, $uploadedFile['file'], $postId);
+        update_field(AttachmentFieldGroup::CAPTION_FIELD_KEY, static::getCaption($file), $attachmentId);
         if (is_wp_error($attachmentId)) {
             return null;
         }
@@ -224,6 +225,7 @@ class WpAttachment
         update_post_meta($attachmentId, '_wp_attachment_image_alt', static::getAlt($file));
         update_post_meta($attachmentId, static::POST_META_COPYRIGHT, $file->copyright ?? '');
         update_post_meta($attachmentId, static::POST_META_COPYRIGHT_URL, $file->copyright_url ?? '');
+        update_field(AttachmentFieldGroup::CAPTION_FIELD_KEY, static::getCaption($file), $attachmentId);
         global $wpdb;
         $wpdb->update(
             'wp_posts',

--- a/src/Models/WpComposite.php
+++ b/src/Models/WpComposite.php
@@ -122,6 +122,16 @@ class WpComposite
         );
     }
 
+    /**
+     * @param $id
+     *
+     * @return null|string
+     */
+    public static function white_albun_id_form_post_id($id)
+    {
+        return get_post_meta($id, static::POST_META_WHITE_ALBUM_ID, true);
+    }
+
     private static function register_acf_fields()
     {
         CompositeFieldGroup::register();

--- a/src/Models/WpComposite.php
+++ b/src/Models/WpComposite.php
@@ -127,7 +127,7 @@ class WpComposite
      *
      * @return null|string
      */
-    public static function white_albun_id_form_post_id($id)
+    public static function white_album_id_form_post_id($id)
     {
         return get_post_meta($id, static::POST_META_WHITE_ALBUM_ID, true);
     }


### PR DESCRIPTION
- BUGFIX: fixes issue where image description was not visible on imported content
- FEATURE: added new prune command that deleted orphaned composites (imported articles that have since been deleted on whitealbum