### PR TITLE
WILL-1744/bugfix-text-item

### DIFF
--- a/contenthub-editor.php
+++ b/contenthub-editor.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: ContentHub Editor
- * Version: 5.22.2
+ * Version: 5.22.3
  * Plugin URI: https://github.com/BenjaminMedia/contenthub-editor
  * Description: This plugin integrates Bonnier Contenthub and adds a custom post type Composite
  * Author: Bonnier - Alf Henderson

--- a/src/Commands/WaContent.php
+++ b/src/Commands/WaContent.php
@@ -306,7 +306,7 @@ class WaContent extends BaseCmd
                 ->map(function ($waWidget) {
                     return collect([
                         'type' => collect([ // Map the type
-                            'Widgets::Text'         => 'seo_text',
+                            'Widgets::Text'         => 'text_item',
                             'Widgets::Image'        => 'image',
                             'Widgets::InsertedCode' => 'inserted_code',
                             'Widgets::Info'         => 'infobox',
@@ -542,7 +542,7 @@ class WaContent extends BaseCmd
                 return $author;
             }
         }
-        return WpAuthor::getDefaultAuthor($waContent->translation->locale);
+        return WpAuthor::getDefaultAuthor($waContent->widget_content->site->locale);
     }
 
     private function fixFaultyImageFormats($content)

--- a/src/Helpers/HtmlToMarkdown.php
+++ b/src/Helpers/HtmlToMarkdown.php
@@ -18,7 +18,6 @@ class HtmlToMarkdown
     {
         if (is_null(self::$instance)) {
             self::$instance = new HtmlConverter();
-            ;
         }
         return self::$instance;
     }


### PR DESCRIPTION
- Fixes an issue were text item widgets dissapeared from articles on import
- Fix `Warning: DOMDocument::loadHTML(): htmlParseEntityRef: expecting ';' in Entity`
- Fix `Notice: Trying to get property 'locale' of non-object`