### PR TITLE
WILL-1659 - Hiding default fields from Composite Content

### DIFF
--- a/contenthub-editor.php
+++ b/contenthub-editor.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: ContentHub Editor
- * Version: 5.25.2
+ * Version: 5.25.3
  * Plugin URI: https://github.com/BenjaminMedia/contenthub-editor
  * Description: This plugin integrates Bonnier Contenthub and adds a custom post type Composite
  * Author: Bonnier - Alf Henderson

--- a/contenthub-editor.php
+++ b/contenthub-editor.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: ContentHub Editor
- * Version: 5.25.1
+ * Version: 5.25.2
  * Plugin URI: https://github.com/BenjaminMedia/contenthub-editor
  * Description: This plugin integrates Bonnier Contenthub and adds a custom post type Composite
  * Author: Bonnier - Alf Henderson

--- a/css/admin.css
+++ b/css/admin.css
@@ -59,3 +59,10 @@ div.image-focalpoint-actions .dashicons-yes {
 div.image-focalpoint-actions .dashicons-no {
   background-color: #a00;
 }
+
+#categorydiv.postbox,
+#tagsdiv-post_tag.postbox,
+#slugdiv.postbox,
+#authordiv.postbox {
+    display:none !important;
+}


### PR DESCRIPTION
Apparently the `hide_on_screen` ACF setting does not actually hide stuff. It's still accessible via screen options.
So now we'll hide it with CSS to ensure that it will not be shown and the editor cannot create tags and categories from composite content.