### PR TITLE
Noticket - Fixing invalid integers in SortBy helper

### DIFF
--- a/contenthub-editor.php
+++ b/contenthub-editor.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: ContentHub Editor
- * Version: 5.25.1
+ * Version: 5.25.2
  * Plugin URI: https://github.com/BenjaminMedia/contenthub-editor
  * Description: This plugin integrates Bonnier Contenthub and adds a custom post type Composite
  * Author: Bonnier - Alf Henderson

--- a/src/Helpers/SortBy.php
+++ b/src/Helpers/SortBy.php
@@ -8,6 +8,7 @@ use Bonnier\WP\ContentHub\Editor\Models\WpComposite;
 use Bonnier\WP\ContentHub\Editor\Models\WpTaxonomy;
 use Bonnier\WP\Cxense\Parsers\Document;
 use Bonnier\WP\Cxense\Services\WidgetDocumentQuery;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
@@ -88,8 +89,8 @@ class SortBy
             ->toArray();
 
         $featuredPostIds =  array_keys($featuredPostIdTimestamps);
-        $postsPerPage = self::$acfWidget[AcfName::FIELD_TEASER_AMOUNT] ?? 4;
-        $offset = self::$acfWidget[AcfName::FIELD_SKIP_TEASERS_AMOUNT] ?? 0;
+        $postsPerPage = Arr::get(self::$acfWidget, AcfName::FIELD_TEASER_AMOUNT) ?: 4;
+        $offset = Arr::get(self::$acfWidget, AcfName::FIELD_SKIP_TEASERS_AMOUNT) ?: 0;
         // Calculate offset factoring in pagination;
         $paginatedOffset = $offset + ((self::$page -1) * $postsPerPage);
 


### PR DESCRIPTION
`$offset` could return empty string instead of the default `0`